### PR TITLE
Use service account key to authorize firebase client and send notification from FCM v1 API

### DIFF
--- a/fcm_firbase_admin.go
+++ b/fcm_firbase_admin.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	messaging "firebase.google.com/go/v4/messaging"
-	logging "github.com/fishbrain/logging-go"
 )
 
 func (this *FcmMsg) makeMulticastMessageData() (*map[string]string, bool) {
@@ -114,8 +113,6 @@ func (this *FcmMsg) makeMulticastMessageData() (*map[string]string, bool) {
 func toFcmRespStatus(resp *messaging.BatchResponse) *FcmResponseStatus {
 	var ok bool
 	var statusCode int = http.StatusInternalServerError
-
-	logging.Log.Infof("Batch response: %v", resp.Responses)
 
 	if resp.SuccessCount > 0 {
 		ok = true

--- a/fcm_test.go
+++ b/fcm_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	messaging "firebase.google.com/go/v4/messaging"
@@ -16,6 +17,11 @@ import (
 
 type fcmMock struct {
 	mock.Mock
+}
+
+func TestMain(m *testing.M) {
+	logging.Init(logging.LoggingConfig{})
+	os.Exit(m.Run())
 }
 
 func (m *fcmMock) SendEachForMulticast(ctx context.Context, mm *messaging.MulticastMessage) (*messaging.BatchResponse, error) {
@@ -301,7 +307,6 @@ func TestSendOnceFirebaseAdminGo_SuccessResponse(t *testing.T) {
 }
 
 func TestSendOnceFirebaseAdminGo_BadResponse(t *testing.T) {
-	logging.Init(logging.LoggingConfig{})
 	c := NewFcmClient("key")
 
 	notificationPayload := NotificationPayload{
@@ -352,7 +357,6 @@ func TestSendOnceFirebaseAdminGo_BadResponse(t *testing.T) {
 }
 
 func TestSendOnceFirebaseAdminGo_MixedResponse(t *testing.T) {
-	logging.Init(logging.LoggingConfig{})
 	c := NewFcmClient("key")
 
 	notificationPayload := NotificationPayload{
@@ -412,7 +416,6 @@ func TestSendOnceFirebaseAdminGo_MixedResponse(t *testing.T) {
 }
 
 func TestMakeMulticastMessageData_Nil(t *testing.T) {
-	logging.Init(logging.LoggingConfig{})
 	msg := FcmMsg{}
 	res, ok := msg.makeMulticastMessageData()
 


### PR DESCRIPTION
This PR switches over from sendOnce to sendOnceFromFirebase.
There are two commits in this PR-
- [Send notifications from firebase admin go](https://github.com/fishbrain/go-fcm/pull/14/commits/6d474bea11b72f5b9987e35eb22cc48bf8e7f2c7)
- [Remove logs and code duplication](https://github.com/fishbrain/go-fcm/pull/14/commits/004a76c491a54c8879ef62da523930c29ea0c32f)

and the first one is the one making the switch.
So [these](https://github.com/fishbrain/go-fcm/pull/14/commits/f1cff45235f931a86b84140c5cfd76b039127ee3) are the relevant changes to review.