### PR TITLE
Handle response better

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -245,10 +245,10 @@ func (this *FcmClient) Send() (*FcmResponseStatus, error) {
 		logging.Log.Infof("AuthorizeAndGetfcmClientFromKey FCM Client: %v", client)
 
 		response, err := this.sendOnceFirebaseAdminGo(client)
-		
+
 		if err != nil {
 			logging.Log.Infof("AuthorizeAndGetfcmClientFromKey Error sending message %v", response)
-		}else {
+		} else {
 			logging.Log.Infof("AuthorizeAndGetfcmClientFromKey Success sending message")
 			return response, err
 		}
@@ -281,11 +281,7 @@ func (this *FcmClient) sendOnceFirebaseAdminGo(client MessagingClient) (*FcmResp
 
 	fcmRespStatus := toFcmRespStatus(batchResponse)
 
-	if fcmRespStatus.Ok {
-		return fcmRespStatus, nil
-	}else {
-		return fcmRespStatus, errors.New("could not send message")
-	}
+	return fcmRespStatus, nil
 }
 
 // parseStatusBody parse FCM response body

--- a/fcm_firbase_admin.go
+++ b/fcm_firbase_admin.go
@@ -115,11 +115,17 @@ func toFcmRespStatus(resp *messaging.BatchResponse) *FcmResponseStatus {
 	var ok bool
 	var statusCode int = http.StatusInternalServerError
 
+	logging.Log.Infof("Batch response: %v", resp.Responses)
+
 	if resp.SuccessCount > 0 {
 		ok = true
 		statusCode = http.StatusOK
 	}
-	logging.Log.Infof("Batch response: %v", resp.Responses)
+
+	if resp.FailureCount > 0 {
+		// NOTE: With Ok set to false bonito will try to inspect responses and handle errors.
+		ok = false
+	}
 
 	status := FcmResponseStatus{
 		Ok:            ok,
@@ -139,13 +145,13 @@ func toFcmResponseResults(original *[]*messaging.SendResponse) *[]map[string]str
 
 	for _, resp := range *original {
 		elem = map[string]string{
-			"Success":   strconv.FormatBool(resp.Success),
-			"MessageID": resp.MessageID,
+			"success":   strconv.FormatBool(resp.Success),
+			"messageID": resp.MessageID,
 		}
 
 		optErr := resp.Error
 		if optErr != nil {
-			elem["Error"] = optErr.Error()
+			elem["error"] = optErr.Error()
 		}
 
 		result = append(result, elem)

--- a/fcm_test.go
+++ b/fcm_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	messaging "firebase.google.com/go/v4/messaging"
+	logging "github.com/fishbrain/logging-go"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -209,6 +210,7 @@ func regIdHandle(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestSendFirebase(t *testing.T) {
+	logging.Init(logging.LoggingConfig{})
 	srv := httptest.NewServer(http.HandlerFunc(regIdHandle))
 	chgUrl(srv)
 	defer srv.Close()
@@ -249,6 +251,7 @@ func TestSendFirebase(t *testing.T) {
 }
 
 func TestSendOnceFirebaseAdminGo_SuccessResponse(t *testing.T) {
+	logging.Init(logging.LoggingConfig{})
 	c := NewFcmClient("key")
 
 	notificationPayload := NotificationPayload{
@@ -289,8 +292,8 @@ func TestSendOnceFirebaseAdminGo_SuccessResponse(t *testing.T) {
 		Canonical_ids: 0,
 		Results: []map[string]string{
 			{
-				"MessageID": "123",
-				"Success":   "true",
+				"messageID": "123",
+				"success":   "true",
 			},
 		},
 		MsgId: 0,
@@ -298,6 +301,7 @@ func TestSendOnceFirebaseAdminGo_SuccessResponse(t *testing.T) {
 }
 
 func TestSendOnceFirebaseAdminGo_BadResponse(t *testing.T) {
+	logging.Init(logging.LoggingConfig{})
 	c := NewFcmClient("key")
 
 	notificationPayload := NotificationPayload{
@@ -338,9 +342,9 @@ func TestSendOnceFirebaseAdminGo_BadResponse(t *testing.T) {
 		Canonical_ids: 0,
 		Results: []map[string]string{
 			{
-				"MessageID": "123",
-				"Success":   "false",
-				"Error":     "something went wrong",
+				"messageID": "123",
+				"success":   "false",
+				"error":     "something went wrong",
 			},
 		},
 		MsgId: 0,
@@ -348,6 +352,7 @@ func TestSendOnceFirebaseAdminGo_BadResponse(t *testing.T) {
 }
 
 func TestSendOnceFirebaseAdminGo_MixedResponse(t *testing.T) {
+	logging.Init(logging.LoggingConfig{})
 	c := NewFcmClient("key")
 
 	notificationPayload := NotificationPayload{
@@ -385,7 +390,7 @@ func TestSendOnceFirebaseAdminGo_MixedResponse(t *testing.T) {
 
 	require.Nil(t, err)
 	require.Equal(t, &FcmResponseStatus{
-		Ok:            true,
+		Ok:            false,
 		StatusCode:    http.StatusOK,
 		MulticastId:   0,
 		Success:       1,
@@ -393,13 +398,13 @@ func TestSendOnceFirebaseAdminGo_MixedResponse(t *testing.T) {
 		Canonical_ids: 0,
 		Results: []map[string]string{
 			{
-				"MessageID": "123",
-				"Success":   "false",
-				"Error":     "something went wrong",
+				"messageID": "123",
+				"success":   "false",
+				"error":     "something went wrong",
 			},
 			{
-				"MessageID": "123",
-				"Success":   "true",
+				"messageID": "123",
+				"success":   "true",
 			},
 		},
 		MsgId: 0,
@@ -407,6 +412,7 @@ func TestSendOnceFirebaseAdminGo_MixedResponse(t *testing.T) {
 }
 
 func TestMakeMulticastMessageData_Nil(t *testing.T) {
+	logging.Init(logging.LoggingConfig{})
 	msg := FcmMsg{}
 	res, ok := msg.makeMulticastMessageData()
 


### PR DESCRIPTION
Changes made 
* It now makes response OK only if there are 0 failure responses inside. Thats from what I see will make bonito handle responses better;
* also keys in 'responses' slice are uncapitalized now, that way bonito will recognize them.

Still a problem: 
* we never have "registration_id" key in responses now, dont know whats the cosequences;
* "error" values checked in bonito could be out of date and will never be hendled properly, we need to check real errors from new API version. 