### PR TITLE
Check if NotificationPayload is present

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -261,11 +261,13 @@ func (this *FcmClient) sendOnceFirebaseAdminGo(client MessagingClient) (*FcmResp
 	message := &messaging.MulticastMessage{
 		Data:   *multicastMessage,
 		Tokens: this.Message.RegistrationIds,
-		Notification: &messaging.Notification{
-			Body:     this.Message.Notification.Body,
-			Title:    this.Message.Notification.Title,
-			ImageURL: this.Message.Notification.Icon,
-		},
+	}
+	
+	if this.Message.Notification != nil {
+		message.Notification = &messaging.Notification{
+			Title: this.Message.Notification.Title,
+			Body:  this.Message.Notification.Body,
+		}
 	}
 
 	batchResponse, err := client.SendEachForMulticast(context.Background(), message)

--- a/fcm_test.go
+++ b/fcm_test.go
@@ -306,6 +306,49 @@ func TestSendOnceFirebaseAdminGo_SuccessResponse(t *testing.T) {
 	}, fcmRespStatus)
 }
 
+func TestSendOnceFirebaseAdminGo_SuccessResponseWhenNoNotificationPayload(t *testing.T) {
+	logging.Init(logging.LoggingConfig{})
+	c := NewFcmClient("key")
+
+	messagingClientMock := new(fcmMock)
+	mockCall := messagingClientMock.On("SendEachForMulticast", mock.Anything, mock.Anything).Return(
+		&messaging.BatchResponse{
+			SuccessCount: 1,
+			FailureCount: 0,
+			Responses: []*messaging.SendResponse{
+				{
+					Success:   true,
+					MessageID: "123",
+					Error:     nil,
+				},
+			},
+		},
+		nil,
+	)
+
+	fcmRespStatus, err := c.sendOnceFirebaseAdminGo(messagingClientMock)
+
+	messagingClientMock.AssertExpectations(t)
+	mockCall.Unset()
+
+	require.Nil(t, err)
+	require.Equal(t, &FcmResponseStatus{
+		Ok:            true,
+		StatusCode:    http.StatusOK,
+		MulticastId:   0,
+		Success:       1,
+		Fail:          0,
+		Canonical_ids: 0,
+		Results: []map[string]string{
+			{
+				"messageID": "123",
+				"success":   "true",
+			},
+		},
+		MsgId: 0,
+	}, fcmRespStatus)
+}
+
 func TestSendOnceFirebaseAdminGo_BadResponse(t *testing.T) {
 	c := NewFcmClient("key")
 


### PR DESCRIPTION
#### Description
Not always does Bonito set the NotificationPayload.
This PR handles the case where we were always assuming NotificationPayload is present and that was resulting in a SEG FAULT

#### Testing
- https://fishbrain.atlassian.net/browse/FIB-41501