### PR TITLE
Update message data payload and send message from firebase admin go

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -211,15 +211,7 @@ func (this *FcmClient) Send() (*FcmResponseStatus, error) {
 	if this.Message.DryRun {
 		logging.Log.Info("Dry run mode enabled")
 
-		client, err := authAndGetFcmClient()
-		if err != nil {
-			logging.Log.Errorf("Error getting messaging client: %s", err)
-			return &FcmResponseStatus{}, err
-		}
-
-		return this.sendOnceFirebaseAdminGo(client)
-
-		client, err = utils.AuthorizeAndGetFirebaseMessagingClient()
+		client, err := utils.AuthorizeAndGetFirebaseMessagingClient()
 		if err != nil {
 			logging.Log.Infof("Error getting messaging client with embedded key: %s", err)
 		}
@@ -249,7 +241,13 @@ func (this *FcmClient) Send() (*FcmResponseStatus, error) {
 		}
 	}
 
-	return this.sendOnce()
+	client, err := authAndGetFcmClient()
+		if err != nil {
+			logging.Log.Errorf("Error getting messaging client: %s", err)
+			return &FcmResponseStatus{}, err
+		}
+
+	return this.sendOnceFirebaseAdminGo(client)
 }
 
 func (this *FcmClient) sendOnceFirebaseAdminGo(client MessagingClient) (*FcmResponseStatus, error) {

--- a/fcm_firbase_admin.go
+++ b/fcm_firbase_admin.go
@@ -15,74 +15,61 @@ func (this *FcmMsg) makeMulticastMessageData() (*map[string]string, bool) {
 	}
 
 	data, ok := this.Data.(map[string]interface{})
+	dataMap := make(map[string]string)
 	if !ok {
 		return nil, false
 	}
 
-	var (
-		title                     string
-		body                      string
-		itemType                  string
-		itemID                    string
-		deepLink                  string
-		imageURL                  string
-		sound                     string
-		actorNickname             string
-		badgeCount                int
-		actionsSerialized         string
-		trackingPayloadSerialized string
-	)
-
 	titleField, ok := data["title"]
 	if ok {
-		title = titleField.(string)
+		dataMap["title"] = titleField.(string)
 	}
 
 	bodyField, ok := data["body"]
 	if ok {
-		body = bodyField.(string)
+		dataMap["body"] = bodyField.(string)
 	}
 
 	itemTypeField, ok := data["item_type"]
 	if ok {
-		itemType = itemTypeField.(string)
+		dataMap["item_type"] = itemTypeField.(string)
 	}
 
 	itemIdField, ok := data["item_id"]
 	if ok {
-		itemID = itemIdField.(string)
+		dataMap["item_id"] = itemIdField.(string)
 	}
 
 	deepLinkField, ok := data["deeplink"]
 	if ok {
-		deepLink = deepLinkField.(string)
+		dataMap["deeplink"] = deepLinkField.(string)
 	}
 
 	imageUrlField, ok := data["image_url"]
 	if ok {
-		imageURL = imageUrlField.(string)
+		dataMap["image_url"] = imageUrlField.(string)
 	}
 
 	soundField, ok := data["sound"]
 	if ok {
-		sound = soundField.(string)
+		dataMap["sound"] = soundField.(string)
 	}
 
 	actorNicknameField, ok := data["actor_nickname"]
 	if ok {
-		actorNickname = actorNicknameField.(string)
+		dataMap["actor_nickname"] = actorNicknameField.(string)
 	}
 
 	badgeCountField, ok := data["badge_count"]
 	if ok {
-		badgeCount = int(badgeCountField.(float64))
+		dataMap["badge_count"] = strconv.Itoa(int(badgeCountField.(float64)))
 	}
 
 	actionsField, ok := data["actions"]
 	if ok {
 		bytes, err := json.Marshal(actionsField)
 		if err == nil {
-			actionsSerialized = string(bytes)
+			dataMap["actions"] = string(bytes)
 		}
 	}
 
@@ -90,22 +77,9 @@ func (this *FcmMsg) makeMulticastMessageData() (*map[string]string, bool) {
 	if ok {
 		bytes, err := json.Marshal(trackingPayloadField)
 		if err == nil {
-			trackingPayloadSerialized = string(bytes)
+			dataMap["tracking_payload"] = string(bytes)
 		}
 	}
-
-	dataMap := make(map[string]string)
-	dataMap["title"] = title
-	dataMap["body"] = body
-	dataMap["item_type"] = itemType
-	dataMap["item_id"] = itemID
-	dataMap["deeplink"] = deepLink
-	dataMap["image_url"] = imageURL
-	dataMap["sound"] = sound
-	dataMap["actor_nickname"] = actorNickname
-	dataMap["badge_count"] = strconv.Itoa(badgeCount)
-	dataMap["actions"] = actionsSerialized
-	dataMap["tracking_payload"] = trackingPayloadSerialized
 
 	return &dataMap, true
 }

--- a/fcm_test.go
+++ b/fcm_test.go
@@ -489,12 +489,5 @@ func TestMakeMulticastMessageData_NotNil(t *testing.T) {
 		"item_type":        "Post",
 		"item_id":          "123",
 		"actions":          `[{"Type":"Like","Value":"like"}]`,
-		"actor_nickname":   "",
-		"badge_count":      "0",
-		"deeplink":         "",
-		"image_url":        "",
-		"sound":            "",
-		"title":            "",
-		"tracking_payload": "",
 	}, res)
 }


### PR DESCRIPTION
#### Description

This PR adds only those fields to the dataMap that we actually get from upstream
For eg not always do we have the Actions coming in from bonito and the previous change was still adding the actions key to the datamap

This ^ led to crashes in Android because we ran into an NPE [here](https://github.com/fishbrain/android/blob/29c1553898a44963bf5a30c198a584f3723a9acb/FishBrainApp/src/main/java/com/fishbrain/app/presentation/push/PushNotificationViewModel.kt#L31) in Android