### PR TITLE
Add imageURL in multicast message

### DIFF
--- a/fcm_firbase_admin.go
+++ b/fcm_firbase_admin.go
@@ -84,6 +84,13 @@ func (this *FcmMsg) makeMulticastMessageData() (*map[string]string, bool) {
 	return &dataMap, true
 }
 
+func addImageURLToMulticastMessage(multicastMessage *messaging.MulticastMessage, imageURL string) (*messaging.MulticastMessage) {	
+	multicastMessage.APNS.FCMOptions.ImageURL = imageURL
+	multicastMessage.APNS.Payload.Aps.MutableContent = true
+	multicastMessage.Android.Notification.ImageURL = imageURL
+	return multicastMessage
+}
+
 func toFcmRespStatus(resp *messaging.BatchResponse) *FcmResponseStatus {
 	var ok bool
 	var statusCode int = http.StatusInternalServerError


### PR DESCRIPTION
##### Description
Based on the following resources
- [Send an image in the notification payload on iOS](https://firebase.google.com/docs/cloud-messaging/ios/send-image#rest)
- [Send an image in the notification payload on Android](https://firebase.google.com/docs/cloud-messaging/android/send-image)

the changes in this PR should make it possible for us to display images in notifications send via fcm

There will be some changes required in iOS and Android (as per the links above)
but these changes should cover the backend side of things