### PR TITLE
Update Aps payload instead of overwriting it

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -298,11 +298,19 @@ func (n *NotificationPayload) asAPS() *messaging.Aps {
 	if err != nil {
 		return &messaging.Aps{
 			Sound: n.Sound,
+			Alert: &messaging.ApsAlert{
+				Body: n.Body,
+				Title: n.Title,
+			},
 		}
 	}
 	return &messaging.Aps{
 		Badge: &badge,
 		Sound: n.Sound,
+		Alert: &messaging.ApsAlert{
+			Body: n.Body,
+			Title: n.Title,
+		},
 	}
 }
 

--- a/fcm_firbase_admin.go
+++ b/fcm_firbase_admin.go
@@ -88,11 +88,7 @@ func addImageURLToMulticastMessage(multicastMessage *messaging.MulticastMessage,
 	multicastMessage.APNS.FCMOptions = &messaging.APNSFCMOptions{
 		ImageURL: imageURL,
 	}
-	multicastMessage.APNS.Payload = &messaging.APNSPayload{
-		Aps: &messaging.Aps{
-			MutableContent: true,
-		},
-	}
+	multicastMessage.APNS.Payload.Aps.MutableContent = true
 	multicastMessage.Android = &messaging.AndroidConfig{
 		Notification: &messaging.AndroidNotification{
 			ImageURL: imageURL,

--- a/fcm_test.go
+++ b/fcm_test.go
@@ -264,6 +264,7 @@ func TestSendOnceFirebaseAdminGo_SuccessResponse(t *testing.T) {
 		Title: "title - foo",
 		Body:  "body - bar",
 		Image: "https://example.com/img.jpg",
+		Sound: "push_1.caf",
 	}
 	c.SetNotificationPayload(&notificationPayload)
 


### PR DESCRIPTION
#### Description
- Change made in previous PR overwrote the values of APS payload which resulted in notifications without sound and badges.
- This PR fixes that.

#### Testing
- After the version of go-fcm is updated in bonito this change will be tested in staging